### PR TITLE
Use Debian slim images as base

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.2
+FROM python:3.11.2-slim
 
 ENV DEVPICLIENT_CLIENTDIR=/devpi/client
 RUN mkdir -p $DEVPICLIENT_CLIENTDIR

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.2
+FROM python:3.11.2-slim
 
 ENV DEVPISERVER_SERVERDIR=/devpi/server
 RUN mkdir -p $DEVPISERVER_SERVERDIR && \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,19 @@
 FROM python:3.11.2-slim
 
+ARG TARGETPLATFORM
+
+# On platform arm/v7, `gcc`, `libc6-dev`, and `libffi-dev` must be installed to
+# be able to compile the `cffi` Python indirect dependency.
+RUN if [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        gcc \
+        libc6-dev \
+        libffi-dev \
+    && \
+    apt-get clean \
+    ; fi
+
 ENV DEVPISERVER_SERVERDIR=/devpi/server
 RUN mkdir -p $DEVPISERVER_SERVERDIR && \
     mkdir /entrypoint.d

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,25 +1,31 @@
 FROM python:3.11.2-slim
 
-ARG TARGETPLATFORM
-
-# On platform arm/v7, `gcc`, `libc6-dev`, and `libffi-dev` must be installed to
-# be able to compile the `cffi` Python indirect dependency.
-RUN if [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-        gcc \
-        libc6-dev \
-        libffi-dev \
-    && \
-    apt-get clean \
-    ; fi
-
 ENV DEVPISERVER_SERVERDIR=/devpi/server
 RUN mkdir -p $DEVPISERVER_SERVERDIR && \
     mkdir /entrypoint.d
 
 COPY requirements.txt /requirements.txt
-RUN pip install --no-cache-dir -r /requirements.txt
+
+# Do a single run command to make the intermediary containers smaller.
+RUN set -ex && \
+# Install packages necessary during the build phase (for all architectures).
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+            build-essential \
+            libffi7 \
+            libffi-dev \
+    && \
+# Install Python dependencies.
+    pip install --no-cache-dir -r /requirements.txt && \
+# Remove everything that is no longer necessary.
+    apt-get remove --purge -y \
+            build-essential \
+            libffi-dev \
+    && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /root/.cache
 
 COPY entrypoint.sh /
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/server/Makefile
+++ b/server/Makefile
@@ -8,7 +8,7 @@ build-alpine: Makefile Dockerfile
 	docker build -t jonasal/devpi-server:local-alpine -f ./Dockerfile-alpine .
 	@echo "Done!  Use docker run jonasal/devpi-server:local-alpine to run"
 
-# Ssee link for more info about how these work:
+# See link for more info about how these work:
 # https://github.com/JonasAlfredsson/docker-nginx-certbot/issues/28
 dev: Makefile Dockerfile
 	docker buildx build --platform linux/amd64,linux/386,linux/arm64,linux/arm/v7 --tag jonasal/devpi-server:dev -f ./Dockerfile ./


### PR DESCRIPTION
Currently, the Debian-based Docker images have a size of ~1GiB, while the Alpine-based ones are close to 10x smaller:

```
jonasal/devpi-client            6.0.2           5959799bce2c   12 days ago         942MB
jonasal/devpi-client            6.0.2-alpine    88f09bd5d3e9   12 days ago         73.3MB
jonasal/devpi-server            6.8.0           03a5175959d3   12 days ago         993MB
jonasal/devpi-server            6.8.0-alpine    726dba98df13   12 days ago         125MB
```

I haven't found any issues with migrating the Debian-based ones to use the `slim` variant, which greatly reduces their size:

```
devpi-client-custom             latest          fe741389ac6d   5 minutes ago       144MB
devpi-server-custom             latest          24634fc1f60e   7 minutes ago       196MB
```